### PR TITLE
Fair implementation

### DIFF
--- a/.github/scripts/generate_metadata_files.py
+++ b/.github/scripts/generate_metadata_files.py
@@ -1,0 +1,106 @@
+"""Generate CITATION.cff and bioschemas.yml from metadata.yml."""
+
+import json
+
+import yaml
+
+METADATA_FILE = "metadata.yml"
+CITATION_FILE = "CITATION.cff"
+BIOSCHEMAS_FILE = "bioschemas.yml"
+
+TITLE_SUFFIX = " - CodeRefinery lesson"
+
+SPDX_LICENSE_URLS = {
+    "CC-BY-4.0": "https://creativecommons.org/licenses/by/4.0/",
+}
+
+
+def load_yaml(path):
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def license_url(spdx_id):
+    return SPDX_LICENSE_URLS.get(spdx_id, spdx_id)
+
+
+def bioschemas_authors(authors):
+    result = []
+    for author in authors:
+        if "family-names" in author:
+            result.append(
+                {
+                    "@type": "Person",
+                    "name": f"{author['given-names']} {author['family-names']}",
+                }
+            )
+        else:
+            result.append({"@type": "Organization", "name": author["name"]})
+    return result
+
+
+def write_citation_cff(meta):
+    citation = {
+        "cff-version": "1.2.0",
+        "message": (
+            "If you use this lesson material, please cite it using "
+            "these metadata."
+        ),
+        "authors": meta["authors"],
+        "title": meta["title"] + TITLE_SUFFIX,
+        "type": "dataset",
+        "abstract": meta.get("abstract", ""),
+        "version": meta["version"],
+        "doi": meta["doi"],
+        "date-released": meta["version"],
+        "url": meta["url"],
+        "license": meta["license"],
+        "repository-code": meta["repository-code"],
+    }
+
+    if meta.get("maintainers"):
+        citation["contact"] = meta["maintainers"]
+
+    with open(CITATION_FILE, "w", encoding="utf-8") as f:
+        yaml.safe_dump(citation, f, sort_keys=False, allow_unicode=True)
+
+
+def write_bioschemas(meta):
+    bioschemas = {
+        "@context": "https://schema.org/",
+        "@type": "LearningResource",
+        "@id": meta["url"],
+        "description": meta.get("abstract", ""),
+        "keywords": ", ".join(meta.get("keywords", [])),
+        "name": meta["title"] + TITLE_SUFFIX,
+        "author": bioschemas_authors(meta["authors"]),
+        # Disabled for now.
+        # "maintainer": bioschemas_authors(meta.get("maintainers", [])),
+        "about": meta.get("abstract", ""),
+        "audience": meta.get("audience", ""),
+        "competencyRequired": meta.get("competencyRequired", ""),
+        "educationalLevel": meta.get("educationalLevel", ""),
+        "identifier": f"https://doi.org/{meta['doi']}",
+        "inLanguage": meta.get("inLanguage", ""),
+        "learningResourceType": meta.get("learningResourceType", ""),
+        "license": license_url(meta["license"]),
+        "teaches": meta.get("teaches", ""),
+        "url": meta["url"],
+        "accessibilitySummary": meta.get("accessibilitySummary", ""),
+        "isPartOf": meta.get("isPartOf", ""),
+        "version": meta["version"],
+    }
+
+    with open(BIOSCHEMAS_FILE, "w", encoding="utf-8") as f:
+        json.dump(bioschemas, f, indent=4)
+        f.write("\n")
+
+
+def main():
+    meta = load_yaml(METADATA_FILE)
+    write_citation_cff(meta)
+    write_bioschemas(meta)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/publish_to_zenodo.py
+++ b/.github/scripts/publish_to_zenodo.py
@@ -1,0 +1,267 @@
+# Based on examples on https://developers.zenodo.org/
+
+import json
+import os
+import requests
+import yaml
+
+ACCESS_TOKEN = os.environ["ZENODO_TOKEN"]
+CONCEPT_ID = os.environ["ZENODO_CONCEPT_ID"]
+
+print(CONCEPT_ID)
+print(ACCESS_TOKEN)
+
+BASE_URL = "https://zenodo.org/api"
+
+TITLE_SUFFIX = " - CodeRefinery lesson"
+
+
+json_headers = {
+    "Authorization": f"Bearer {ACCESS_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+upload_headers = {
+    "Authorization": f"Bearer {ACCESS_TOKEN}"
+}
+
+def load_metadata():
+    with open("metadata.yml", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def authors_to_creators(authors):
+    creators = []
+
+    for author in authors:
+        if "family-names" in author:
+            creator = {
+                "name": (
+                    f"{author['family-names']}, "
+                    f"{author['given-names']}"
+                )
+            }
+        else:
+            creator = {"name": author["name"]}
+
+        if author.get("orcid"):
+            creator["orcid"] = author["orcid"].removeprefix("https://orcid.org/")
+
+        creators.append(creator)
+
+    return creators
+
+
+
+# Load metadata from metadata.yml
+
+meta = load_metadata()
+
+description = meta.get("abstract", "")
+
+if meta.get("repository-code"):
+    description += (
+        f'<br><p>Source code: '
+        f'<a href="{meta["repository-code"]}">{meta["repository-code"]}</a></p>'
+    )
+
+if meta.get("url"):
+    description += (
+        f'<br><p>Lesson website: '
+        f'<a href="{meta["url"]}">{meta["url"]}</a></p>'
+    )
+
+description += (
+    '<br><p>CodeRefinery website: '
+    '<a href="https://coderefinery.org">https://coderefinery.org</a></p>'
+)
+
+metadata = {
+    "title": meta["title"] + TITLE_SUFFIX,
+    "upload_type": "lesson",
+    "description": description,
+    "creators": authors_to_creators(meta["authors"]),
+    "keywords": meta.get("keywords", []),
+    "version": meta.get("version"),
+    "license": meta.get("license"),
+}
+
+if meta.get("maintainers"):
+    contributors = authors_to_creators(meta["maintainers"])
+    for contributor in contributors:
+        contributor["type"] = "ContactPerson"
+    metadata["contributors"] = contributors
+
+
+# Discard any unpublished draft left over from a previous failed run.
+# Zenodo only allows one unpublished new-version draft per concept at
+# a time, so a stray one would make the newversion call below fail.
+
+r = requests.get(
+    f"{BASE_URL}/deposit/depositions",
+    params={"q": f"conceptrecid:{CONCEPT_ID}", "all_versions": "true"},
+    headers=json_headers,
+)
+
+r.raise_for_status()
+
+for dep in r.json():
+    if not dep.get("submitted"):
+        print(f"Discarding leftover draft {dep['id']}")
+        requests.delete(dep["links"]["self"], headers=json_headers).raise_for_status()
+
+
+# Find the current latest version of this concept.
+# newversion only works when called on the latest version's own
+# deposit ID, and that ID changes with every new release.
+
+r = requests.get(
+    f"{BASE_URL}/records",
+    params={"q": f"conceptrecid:{CONCEPT_ID}", "all_versions": "true"},
+    headers=json_headers,
+)
+
+r.raise_for_status()
+
+hits = r.json()["hits"]["hits"]
+
+latest_id = hits[0]["id"]
+for hit in hits[1:]:
+    if hit["id"] > latest_id:
+        latest_id = hit["id"]
+
+print(f"Latest existing version: {latest_id}")
+
+
+# Create new version of existing concept DOI
+
+r = requests.post(
+    f"{BASE_URL}/deposit/depositions/{latest_id}/actions/newversion",
+    headers=json_headers)
+
+r.raise_for_status()
+
+latest_draft = r.json()["links"]["latest_draft"]
+
+
+# Get draft deposition information
+
+r = requests.get(
+    latest_draft,
+    headers=json_headers,
+)
+
+r.raise_for_status()
+
+deposition = r.json()
+
+deposition_id = deposition["id"]
+bucket_url = deposition["links"]["bucket"]
+
+print(f"Draft deposition: {deposition_id}")
+
+
+# newversion copies over the previous version's files. Remove them so
+# this version ends up with only its own zip and PDF.
+
+for f in deposition.get("files", []):
+    requests.delete(
+        f"{BASE_URL}/deposit/depositions/{deposition_id}/files/{f['id']}",
+        headers=json_headers,
+    ).raise_for_status()
+
+    print(f"Removed inherited file {f['filename']}")
+
+# Upload lesson PDF from the gh-pages branch
+# (built by sphinx.yml as OUTPUT_BASENAME.pdf, OUTPUT_BASENAME being
+# "{owner}-{repo}")
+
+tag = os.environ["GITHUB_REF_NAME"]
+repo_name = os.environ['GITHUB_REPOSITORY']
+owner, repo = repo_name.split("/", 1)
+
+pdf_source_name = f"{owner}-{repo}.pdf"
+pdf_name = f"{owner}-{repo}-{tag}.pdf"
+
+pdf_url = (
+    f"https://raw.githubusercontent.com/"
+    f"{repo_name}/gh-pages/{pdf_source_name}"
+)
+
+pdf_download = requests.get(pdf_url)
+pdf_download.raise_for_status()
+
+with open(pdf_name, "wb") as fp:
+    fp.write(pdf_download.content)
+
+with open(pdf_name, "rb") as fp:
+    r = requests.put(
+        f"{bucket_url}/{pdf_name}",
+        data=fp,
+        headers=upload_headers
+    )
+
+r.raise_for_status()
+
+print(f"Uploaded {pdf_name}")
+
+# Upload release archive
+
+
+archive_url = (
+    f"https://github.com/"
+    f"{repo_name}"
+    f"/archive/refs/tags/{tag}.zip"
+)
+
+archive_name = f"{owner}-{repo}-{tag}.zip"
+
+download = requests.get(archive_url)
+download.raise_for_status()
+
+with open(archive_name, "wb") as fp:
+    fp.write(download.content)
+
+with open(archive_name, "rb") as fp:
+    r = requests.put(
+        f"{bucket_url}/{archive_name}",
+        data=fp,
+        headers=upload_headers
+    )
+
+r.raise_for_status()
+
+print(f"Uploaded {archive_name}")
+
+
+# Update metadata
+
+data = {
+    "metadata": metadata
+}
+
+r = requests.put(
+    f"{BASE_URL}/deposit/depositions/{deposition_id}",
+    data=json.dumps(data),
+    headers=json_headers
+)
+
+r.raise_for_status()
+
+print("Metadata updated")
+
+
+# Publish
+
+
+r = requests.post(
+    f"{BASE_URL}/deposit/depositions/{deposition_id}/actions/publish",
+    headers=json_headers,
+)
+
+r.raise_for_status()
+
+record = r.json()
+
+print(f"Published DOI: {record.get('doi')}")
+print(f"Record URL: {record['links']['html']}")

--- a/.github/workflows/generate-metadata.yml
+++ b/.github/workflows/generate-metadata.yml
@@ -1,0 +1,32 @@
+name: Generate metadata files
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - metadata.yml
+
+jobs:
+  generate:
+    name: Generate CITATION.cff and bioschemas.yml
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Generate CITATION.cff and bioschemas.yml
+        run: python .github/scripts/generate_metadata_files.py
+
+      - name: Commit generated files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CITATION.cff bioschemas.yml
+          git diff --staged --quiet || git commit -m "Regenerate CITATION.cff and bioschemas.yml from metadata.yml"
+          git push

--- a/.github/workflows/zenodo.yml
+++ b/.github/workflows/zenodo.yml
@@ -1,0 +1,27 @@
+name: Publish Release to Zenodo
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  zenodo:
+    runs-on: ubuntu-latest
+    environment: Zenodo
+
+    permissions:
+      contents: read
+
+    env:
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+      ZENODO_CONCEPT_ID: ${{ vars.ZENODO_CONCEPT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          pip install requests pyyaml
+
+      - name: Create Zenodo deposition
+        run: python .github/scripts/publish_to_zenodo.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /venv*
 .jupyter_cache
 jupyter_execute
+*DS_Store

--- a/content/conf.py
+++ b/content/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_lesson",
     # remove once sphinx_rtd_theme updated for contrast and accessibility:
     "sphinx_rtd_theme_ext_color_contrast",
+    "lesson_metadata",
 ]
 
 # Settings for myst_nb:

--- a/content/index.md
+++ b/content/index.md
@@ -84,6 +84,15 @@ workshop-jupyter-basics
 workshop-datasets
 ```
 
+```{toctree}
+:maxdepth: 1
+:caption: About
+
+All lessons <https://coderefinery.org/lessons/core/>
+CodeRefinery <https://coderefinery.org/>
+reusing.md
+```
+
 (learner-personas)=
 
 ## Who is the course for?

--- a/content/lesson_metadata.py
+++ b/content/lesson_metadata.py
@@ -1,0 +1,65 @@
+"""Sphinx directive that renders metadata.yml as a table."""
+
+import os
+
+import yaml
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+
+def _author_name(author):
+    if "family-names" in author:
+        return f"{author['given-names']} {author['family-names']}"
+    return author["name"]
+
+
+class LessonMetadataDirective(Directive):
+    """Renders the repository's metadata.yml as an HTML table."""
+
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+
+    def run(self):
+        env = self.state.document.settings.env
+        metadata_path = os.path.join(env.srcdir, "..", "metadata.yml")
+
+        with open(metadata_path, encoding="utf-8") as f:
+            meta = yaml.safe_load(f)
+
+        fields = [
+            ("Title", meta.get("title")),
+            (
+                "Authors",
+                ", ".join(_author_name(a) for a in meta.get("authors", [])),
+            ),
+            ("Version", meta.get("version", "")),
+            ("DOI", meta.get("doi")),
+            ("License", meta.get("license")),
+            ("Lesson website", meta.get("url")),
+            ("Source repository", meta.get("repository-code")),
+            ("Keywords", ", ".join(meta.get("keywords", []))),
+            ("Educational level", meta.get("educationalLevel")),
+            ("Language", meta.get("inLanguage")),
+            ("Teaches", meta.get("teaches")),
+            ("Is part of", meta.get("isPartOf")),
+            ("Audience", meta.get("audience")),
+            ("Competency required", meta.get("competencyRequired")),
+            ("Accessibility summary", meta.get("accessibilitySummary")),
+            ("Learning resource type", meta.get("learningResourceType")),
+        ]
+
+        rows = "\n".join(
+            f"<tr><th>{label}</th><td>{value}</td></tr>"
+            for label, value in fields
+            if value
+        )
+
+        html = f'<table class="docutils lesson-metadata-table">\n{rows}\n</table>'
+
+        return [nodes.raw("", html, format="html")]
+
+
+def setup(app):
+    app.add_directive("lesson-metadata", LessonMetadataDirective)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/content/reusing.md
+++ b/content/reusing.md
@@ -1,0 +1,70 @@
+# Reusing
+
+This lesson material is free to reuse, adapt, and cite. This page collects
+everything you need to do so.
+
+## How to cite this lesson
+
+If you use this lesson material, please cite it using this DOI:
+
+<https://doi.org/10.5281/zenodo.19335927>
+
+The machine-readable citation record is kept in `CITATION.cff`
+at the root of this lesson's repository, which lists the full set of
+contributing authors and stays up to date as the lesson evolves.
+
+## Structured metadata
+
+This lesson also publishes its metadata as machine-readable
+[Bioschemas](https://bioschemas.org/) / [schema.org](https://schema.org/)
+structured data, embedded as JSON-LD on every page of this site. 
+
+All of this lesson's metadata is generated from a single source,
+`metadata.yml`,
+rendered here directly at build time:
+
+```{lesson-metadata}
+```
+
+## License
+
+### Website template
+
+The website template is maintained by [CodeRefinery](https://coderefinery.org/)
+and rendered with [sphinx-lesson: structured lessons with Sphinx](https://coderefinery.github.io/sphinx-lesson/).
+
+### Instructional material
+
+All CodeRefinery instructional material is made available under the
+[Creative Commons Attribution license (CC-BY-4.0)](https://creativecommons.org/licenses/by/4.0/).
+The following is a human-readable summary of (and not a substitute for)
+the [full legal text of the CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+You are free:
+
+- to **Share** - copy and redistribute the material in any medium or format
+- to **Adapt** - remix, transform, and build upon the material
+
+for any purpose, even commercially. The licensor cannot revoke these freedoms as long as you follow these license terms:
+
+- **Attribution** - You must give appropriate credit
+  (mentioning that your work is derived from work that is Copyright
+  (c) CodeRefinery and, where practical, linking to
+  <https://coderefinery.org>, provide
+  a [link to the license](https://creativecommons.org/licenses/by/4.0/),
+  and indicate if changes were made. You may do so in any
+  reasonable manner, but not in any way that suggests the licensor
+  endorses you or your use.
+
+**No additional restrictions** - You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.
+With the understanding that:
+
+- You do not have to comply with the license for elements of the material in
+  the public domain or where your use is permitted by an applicable exception
+  or limitation.
+- No warranties are given. The license may not give you all of the
+  permissions necessary for your intended use. For example, other
+  rights such as publicity, privacy, or moral rights may limit how
+  you use the material.
+

--- a/metadata.yml
+++ b/metadata.yml
@@ -26,7 +26,7 @@ abstract: "A CodeRefinery lesson providing a practical framework for researchers
 # YAML date. Used in CITATION.cff, bioschemas.yml, and the Zenodo
 # deposit. Also used as CITATION.cff's date-released, since for this
 # lesson the two always match - there's no separate date-released field.
-version: "2026-08-07"
+version: "2026-08-10"
 
 # Text. The concept DOI, which stays constant across all versions -
 # Zenodo assigns the version-specific DOI itself. Used in bioschemas.yml

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,0 +1,126 @@
+# Master metadata for this lesson.
+#
+# CITATION.cff and bioschemas.yml are both generated from this file by
+# generate_metadata_files.py upon push to main, and publish_to_zenodo.py reads it
+# directly too. Edit this file, not the generated ones, it will generate CITATION.cff and bioschemas.yml upcon push to main branch.
+#
+# All values are quoted deliberately, so they always load as plain
+# strings (not YAML dates/numbers) - see version below.
+
+
+# Text. Base lesson title. " - CodeRefinery lesson" is appended
+# automatically when generating CITATION.cff/bioschemas.yml and when
+# publishing to Zenodo - do not include it here.
+title: "Responsible Use of Generative AI in Assisted Coding"
+
+# Text. Used as CITATION.cff's abstract, bioschemas' description/about,
+# and the start of the Zenodo description.
+abstract: "A CodeRefinery lesson providing a practical framework for researchers who
+  want to use AI coding assistants responsibly. The lesson covers three scenarios of
+  increasing automation (chat-based coding, IDE integration, and agentic coding),
+  security considerations including hallucinated packages and prompt injection, and
+  mitigation strategies. Includes a hands-on workshop on data exploration and
+  visualisation with Python and generative AI."
+
+# Text (ISO 8601 date, YYYY-MM-DD), quoted so it isn't parsed as a
+# YAML date. Used in CITATION.cff, bioschemas.yml, and the Zenodo
+# deposit. Also used as CITATION.cff's date-released, since for this
+# lesson the two always match - there's no separate date-released field.
+version: "2026-08-07"
+
+# Text. The concept DOI, which stays constant across all versions -
+# Zenodo assigns the version-specific DOI itself. Used in bioschemas.yml
+# as identifier (https://doi.org/<doi>).
+doi: "10.5281/zenodo.19335927"
+
+# Text (URL). The lesson's rendered website. Used as bioschemas' @id/url
+# and linked in the Zenodo description.
+url: "https://coderefinery.github.io/coding-with-ai"
+
+# Text (SPDX license identifier, e.g. CC-BY-4.0). Converted to a full
+# license URL for bioschemas.yml via SPDX_LICENSE_URLS in
+# generate_metadata_files.py; passed through as-is to CITATION.cff and
+# Zenodo.
+license: "CC-BY-4.0"
+
+# Text (URL). Source repository, linked in the Zenodo description and
+# included in CITATION.cff.
+repository-code: "https://github.com/coderefinery/coding-with-ai"
+
+# List of Text. Not used in CITATION.cff. Comma-joined for
+# bioschemas.yml's keywords string, and used as Zenodo's keywords list.
+keywords:
+  - "generative AI"
+  - "coding"
+  - "research software"
+  - "responsible AI"
+  - "data visualisation"
+  - "CodeRefinery"
+  - "reproducibility"
+ 
+
+# Text or DefinedTerm per schema.org. bioschemas.yml only. E.g.
+# "Beginner", "Intermediate", "Advanced".
+educationalLevel: "Beginner"
+
+# Text (BCP47 language tag, e.g. "en-UK"). bioschemas.yml only. Not the
+# same format Zenodo's own "language" field would expect (ISO 639-2/3),
+# so this isn't reused for the Zenodo deposit.
+inLanguage: "en-UK"
+
+# Text. bioschemas.yml only. Learning outcomes / what this lesson
+# teaches.
+teaches: ""
+
+# URL or CreativeWork per schema.org. bioschemas.yml only. The
+# collection/series this lesson belongs to.
+isPartOf: "https://coderefinery.org"
+
+# Audience (structured object) per schema.org - NOT plain Text, even
+# though it's currently stored and emitted as a bare string. bioschemas.yml
+# only. 
+audience: ""
+
+# Text, DefinedTerm, or URL per schema.org. bioschemas.yml only.
+# Prerequisites/prior knowledge needed. 
+competencyRequired: ""
+
+# Text per schema.org. bioschemas.yml only. Describes accessibility
+# features of the material. 
+accessibilitySummary: ""
+
+# Text or DefinedTerm per schema.org. bioschemas.yml only. E.g.
+# "lesson", "exercise", "video". 
+learningResourceType: "lesson"
+
+# Disabled for now. List of CFF-style entries, same shape as authors
+# below: either {name: "Org"} for organizations, or {family-names,
+# given-names, orcid (optional)} for people. When enabled: mapped to
+# CITATION.cff's contact field, bioschemas.yml's maintainer property,
+# and Zenodo's contributors (as ContactPerson).
+# maintainers:
+# - family-names: ""
+#   given-names: ""
+
+# List of CFF-style author entries: either {name: "Org"} for
+# organizations, or {family-names, given-names, orcid (optional)} for
+# people. orcid, if given, must be the full https://orcid.org/... URL -
+# publish_to_zenodo.py strips that prefix before sending it to Zenodo.
+# Used for CITATION.cff authors, bioschemas.yml's author list
+# (mapped to Person/Organization), and Zenodo's creators.
+authors:
+- name: "CodeRefinery"
+- family-names: "Glerean"
+  given-names: "Enrico"
+  orcid: "https://orcid.org/0000-0003-0624-675X"
+- family-names: "Lindi"
+  given-names: "Bjørn"
+- family-names: "Pöhner"
+  given-names: "Ina"
+- family-names: "Rantaharju"
+  given-names: "Jarno"
+- family-names: "Christ"
+  given-names: "Simon"
+- family-names: "Pfau"
+  given-names: "Thomas"
+


### PR DESCRIPTION
Adds a machine-readable metadata pipeline for the lesson and a "Reusing" page that surfaces it.

- metadata.yml (new) — single source of truth for the lesson's citation/schema metadata: title, abstract, authors, version, DOI, license, repo/website URLs, keywords, and the teaches field (learning outcomes lifted from content/index.rst).
- .github/workflows/generate-metadata.yml + .github/scripts/generate_metadata_files.py (new) — on push to main touching metadata.yml, regenerates CITATION.cff and a new bioschemas.yml from it and commits them back.
- .github/workflows/zenodo.yml + .github/scripts/publish_to_zenodo.py (new) — on a published GitHub release, creates a new Zenodo version under the lesson's existing concept DOI and publishes it with metadata from metadata.yml.
- content/reusing.md (new) — citation info (DOI, CITATION.cff pointer), a live-rendered metadata table, and the license section. content/index.rst's "Reusing" toctree entry now points here instead of the generic coderefinery.org/lessons/reusing/ page.
- content/lesson_metadata.py (new) — Sphinx extension adding a {lesson-metadata} directive that renders metadata.yml as an HTML table (used on the new page).
- content/conf.py — registered lesson_metadata in extensions and uncommented sys.path.insert(0, os.path.abspath('.')), both required for the new extension to import.